### PR TITLE
fixed relative imports for yt-search and yt-search-video

### DIFF
--- a/elements.html
+++ b/elements.html
@@ -39,6 +39,6 @@
 <link rel="import" href="../x-property-inspector/metadata.html">
 <link rel="import" href="../x-tags/metadata.html">
 <link rel="import" href="../x-tree/metadata.html"> -->
-<link rel="import" href="../yt-search-video/yt-search-video.html">
-<link rel="import" href="../yt-search/yt-search.html">
+<link rel="import" href="../yt-video/yt-search-video.html">
+<link rel="import" href="../yt-video/yt-search.html">
 <link rel="import" href="../yt-video/yt-video.html">


### PR DESCRIPTION
yt-search and yt-search-video used to be separate repos I guess but now they are both in yt-video.
